### PR TITLE
go fmt with Go 1.20

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -51,24 +51,24 @@ type cleanuper interface {
 // goroutines. Each test should create a new Controller and invoke Finish via
 // defer.
 //
-//   func TestFoo(t *testing.T) {
-//     ctrl := gomock.NewController(t)
-//     defer ctrl.Finish()
-//     // ..
-//   }
+//	func TestFoo(t *testing.T) {
+//	  ctrl := gomock.NewController(t)
+//	  defer ctrl.Finish()
+//	  // ..
+//	}
 //
-//   func TestBar(t *testing.T) {
-//     t.Run("Sub-Test-1", st) {
-//       ctrl := gomock.NewController(st)
-//       defer ctrl.Finish()
-//       // ..
-//     })
-//     t.Run("Sub-Test-2", st) {
-//       ctrl := gomock.NewController(st)
-//       defer ctrl.Finish()
-//       // ..
-//     })
-//   })
+//	func TestBar(t *testing.T) {
+//	  t.Run("Sub-Test-1", st) {
+//	    ctrl := gomock.NewController(st)
+//	    defer ctrl.Finish()
+//	    // ..
+//	  })
+//	  t.Run("Sub-Test-2", st) {
+//	    ctrl := gomock.NewController(st)
+//	    defer ctrl.Finish()
+//	    // ..
+//	  })
+//	})
 type Controller struct {
 	// T should only be called within a generated mock. It is not intended to
 	// be used in user code and may be changed in future versions. T is the

--- a/gomock/doc.go
+++ b/gomock/doc.go
@@ -15,18 +15,19 @@
 // Package gomock is a mock framework for Go.
 //
 // Standard usage:
-//   (1) Define an interface that you wish to mock.
-//         type MyInterface interface {
-//           SomeMethod(x int64, y string)
-//         }
-//   (2) Use mockgen to generate a mock from the interface.
-//   (3) Use the mock in a test:
-//         func TestMyThing(t *testing.T) {
-//           mockCtrl := gomock.NewController(t)//
-//           mockObj := something.NewMockMyInterface(mockCtrl)
-//           mockObj.EXPECT().SomeMethod(4, "blah")
-//           // pass mockObj to a real object and play with it.
-//         }
+//
+//	(1) Define an interface that you wish to mock.
+//	      type MyInterface interface {
+//	        SomeMethod(x int64, y string)
+//	      }
+//	(2) Use mockgen to generate a mock from the interface.
+//	(3) Use the mock in a test:
+//	      func TestMyThing(t *testing.T) {
+//	        mockCtrl := gomock.NewController(t)//
+//	        mockObj := something.NewMockMyInterface(mockCtrl)
+//	        mockObj.EXPECT().SomeMethod(4, "blah")
+//	        // pass mockObj to a real object and play with it.
+//	      }
 //
 // By default, expected calls are not enforced to run in any particular order.
 // Call order dependency can be enforced by use of InOrder and/or Call.After.
@@ -37,17 +38,17 @@
 //
 // Example of using Call.After to chain expected call order:
 //
-//     firstCall := mockObj.EXPECT().SomeMethod(1, "first")
-//     secondCall := mockObj.EXPECT().SomeMethod(2, "second").After(firstCall)
-//     mockObj.EXPECT().SomeMethod(3, "third").After(secondCall)
+//	firstCall := mockObj.EXPECT().SomeMethod(1, "first")
+//	secondCall := mockObj.EXPECT().SomeMethod(2, "second").After(firstCall)
+//	mockObj.EXPECT().SomeMethod(3, "third").After(secondCall)
 //
 // Example of using InOrder to declare expected call order:
 //
-//     gomock.InOrder(
-//         mockObj.EXPECT().SomeMethod(1, "first"),
-//         mockObj.EXPECT().SomeMethod(2, "second"),
-//         mockObj.EXPECT().SomeMethod(3, "third"),
-//     )
+//	gomock.InOrder(
+//	    mockObj.EXPECT().SomeMethod(1, "first"),
+//	    mockObj.EXPECT().SomeMethod(2, "second"),
+//	    mockObj.EXPECT().SomeMethod(3, "third"),
+//	)
 //
 // The standard TestReporter most users will pass to `NewController` is a
 // `*testing.T` from the context of the test. Note that this will use the

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -283,8 +283,9 @@ func Any() Matcher { return anyMatcher{} }
 // Eq returns a matcher that matches on equality.
 //
 // Example usage:
-//   Eq(5).Matches(5) // returns true
-//   Eq(5).Matches(4) // returns false
+//
+//	Eq(5).Matches(5) // returns true
+//	Eq(5).Matches(4) // returns false
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
 
 // Len returns a matcher that matches on length. This matcher returns false if
@@ -296,17 +297,19 @@ func Len(i int) Matcher {
 // Nil returns a matcher that matches if the received value is nil.
 //
 // Example usage:
-//   var x *bytes.Buffer
-//   Nil().Matches(x) // returns true
-//   x = &bytes.Buffer{}
-//   Nil().Matches(x) // returns false
+//
+//	var x *bytes.Buffer
+//	Nil().Matches(x) // returns true
+//	x = &bytes.Buffer{}
+//	Nil().Matches(x) // returns false
 func Nil() Matcher { return nilMatcher{} }
 
 // Not reverses the results of its given child matcher.
 //
 // Example usage:
-//   Not(Eq(5)).Matches(4) // returns true
-//   Not(Eq(5)).Matches(5) // returns false
+//
+//	Not(Eq(5)).Matches(4) // returns true
+//	Not(Eq(5)).Matches(5) // returns false
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}
@@ -318,12 +321,13 @@ func Not(x interface{}) Matcher {
 // function is assignable to the type of the parameter to this function.
 //
 // Example usage:
-//   var s fmt.Stringer = &bytes.Buffer{}
-//   AssignableToTypeOf(s).Matches(time.Second) // returns true
-//   AssignableToTypeOf(s).Matches(99) // returns false
 //
-//   var ctx = reflect.TypeOf((*context.Context)(nil)).Elem()
-//   AssignableToTypeOf(ctx).Matches(context.Background()) // returns true
+//	var s fmt.Stringer = &bytes.Buffer{}
+//	AssignableToTypeOf(s).Matches(time.Second) // returns true
+//	AssignableToTypeOf(s).Matches(99) // returns false
+//
+//	var ctx = reflect.TypeOf((*context.Context)(nil)).Elem()
+//	AssignableToTypeOf(ctx).Matches(context.Background()) // returns true
 func AssignableToTypeOf(x interface{}) Matcher {
 	if xt, ok := x.(reflect.Type); ok {
 		return assignableToTypeOfMatcher{xt}
@@ -334,8 +338,9 @@ func AssignableToTypeOf(x interface{}) Matcher {
 // InAnyOrder is a Matcher that returns true for collections of the same elements ignoring the order.
 //
 // Example usage:
-//   InAnyOrder([]int{1, 2, 3}).Matches([]int{1, 3, 2}) // returns true
-//   InAnyOrder([]int{1, 2, 3}).Matches([]int{1, 2}) // returns false
+//
+//	InAnyOrder([]int{1, 2, 3}).Matches([]int{1, 3, 2}) // returns true
+//	InAnyOrder([]int{1, 2, 3}).Matches([]int{1, 2}) // returns false
 func InAnyOrder(x interface{}) Matcher {
 	return inAnyOrderMatcher{x}
 }

--- a/mockgen/internal/tests/import_embedded_interface/bugreport_test.go
+++ b/mockgen/internal/tests/import_embedded_interface/bugreport_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package bugreport
 
 import (

--- a/mockgen/internal/tests/import_embedded_interface/ersatz/ersatz.go
+++ b/mockgen/internal/tests/import_embedded_interface/ersatz/ersatz.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ersatz
 
 type Embedded interface {

--- a/mockgen/internal/tests/import_embedded_interface/faux/conflict.go
+++ b/mockgen/internal/tests/import_embedded_interface/faux/conflict.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package faux
 
 import "go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/other/log"

--- a/mockgen/internal/tests/import_embedded_interface/faux/faux.go
+++ b/mockgen/internal/tests/import_embedded_interface/faux/faux.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package faux
 
 import (

--- a/mockgen/internal/tests/import_embedded_interface/net_test.go
+++ b/mockgen/internal/tests/import_embedded_interface/net_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package bugreport
 
 import (

--- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/ersatz.go
+++ b/mockgen/internal/tests/import_embedded_interface/other/ersatz/ersatz.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ersatz
 
 type Embedded interface {

--- a/mockgen/internal/tests/import_embedded_interface/other/log/log.go
+++ b/mockgen/internal/tests/import_embedded_interface/other/log/log.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package log
 
 func Foo() {}


### PR DESCRIPTION
from Go 1.19, `go fmt` reformats doc comments.

https://go.dev/doc/go1.19#go-doc

> Go 1.19 adds support for links, lists, and clearer headings in doc comments. As part of this change, [gofmt](https://go.dev/cmd/gofmt) now reformats doc comments to make their rendered meaning clearer. See “[Go Doc Comments](https://go.dev/doc/comment)” for syntax details and descriptions of common mistakes now highlighted by gofmt. As another part of this change, the new package [go/doc/comment](https://go.dev/pkg/go/doc/comment/) provides parsing and reformatting of doc comments as well as support for rendering them to HTML, Markdown, and text.