### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 (29 Jun 2023)
+
+This is a minor version that mirrors the original golang/mock
+project that this project originates from.
+
+Any users on golang/mock project should be able to migrate to
+this project as-is, and expect exact same set of features (apart
+from supported Go versions. See [README](README.md#supported-go-versions)
+for more details.


### PR DESCRIPTION
This preps v0.1.0 release. Added a CHANGELOG
file to keep track of release changes according
to semver.

Ref #17.