### PR TITLE
mockgen: replace io/ioutil with io and os package

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -37,10 +36,10 @@ import (
 	"strings"
 	"unicode"
 
-	"go.uber.org/mock/mockgen/model"
-
 	"golang.org/x/mod/modfile"
 	toolsimports "golang.org/x/tools/imports"
+
+	"go.uber.org/mock/mockgen/model"
 )
 
 const (
@@ -151,7 +150,7 @@ func main() {
 		g.mockNames = parseMockNames(*mockNames)
 	}
 	if *copyrightFile != "" {
-		header, err := ioutil.ReadFile(*copyrightFile)
+		header, err := os.ReadFile(*copyrightFile)
 		if err != nil {
 			log.Fatalf("Failed reading copyright file: %v", err)
 		}
@@ -167,7 +166,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(*destination), os.ModePerm); err != nil {
 			log.Fatalf("Unable to create directory: %v", err)
 		}
-		existing, err := ioutil.ReadFile(*destination)
+		existing, err := os.ReadFile(*destination)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Fatalf("Failed reading pre-exiting destination file: %v", err)
 		}
@@ -798,7 +797,7 @@ func parsePackageImport(srcDir string) (string, error) {
 	if moduleMode != "off" {
 		currentDir := srcDir
 		for {
-			dat, err := ioutil.ReadFile(filepath.Join(currentDir, "go.mod"))
+			dat, err := os.ReadFile(filepath.Join(currentDir, "go.mod"))
 			if os.IsNotExist(err) {
 				if currentDir == filepath.Dir(currentDir) {
 					// at the root

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -369,17 +368,9 @@ func Test_createPackageMap(t *testing.T) {
 }
 
 func TestParsePackageImport_FallbackGoPath(t *testing.T) {
-	goPath, err := ioutil.TempDir("", "gopath")
-	if err != nil {
-		t.Error(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(goPath); err != nil {
-			t.Error(err)
-		}
-	}()
+	goPath := t.TempDir()
 	srcDir := filepath.Join(goPath, "src/example.com/foo")
-	err = os.MkdirAll(srcDir, 0755)
+	err := os.MkdirAll(srcDir, 0755)
 	if err != nil {
 		t.Error(err)
 	}
@@ -404,33 +395,17 @@ func TestParsePackageImport_FallbackMultiGoPath(t *testing.T) {
 	var goPathList []string
 
 	// first gopath
-	goPath, err := ioutil.TempDir("", "gopath1")
-	if err != nil {
-		t.Error(err)
-	}
+	goPath := t.TempDir()
 	goPathList = append(goPathList, goPath)
-	defer func() {
-		if err = os.RemoveAll(goPath); err != nil {
-			t.Error(err)
-		}
-	}()
 	srcDir := filepath.Join(goPath, "src/example.com/foo")
-	err = os.MkdirAll(srcDir, 0755)
+	err := os.MkdirAll(srcDir, 0755)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// second gopath
-	goPath, err = ioutil.TempDir("", "gopath2")
-	if err != nil {
-		t.Error(err)
-	}
+	goPath = t.TempDir()
 	goPathList = append(goPathList, goPath)
-	defer func() {
-		if err = os.RemoveAll(goPath); err != nil {
-			t.Error(err)
-		}
-	}()
 
 	goPaths := strings.Join(goPathList, string(os.PathListSeparator))
 	key := "GOPATH"

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -26,8 +26,8 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -774,7 +774,7 @@ func isVariadic(f *ast.FuncType) bool {
 
 // packageNameOfDir get package import path via dir
 func packageNameOfDir(srcDir string) (string, error) {
-	files, err := ioutil.ReadDir(srcDir)
+	files, err := os.ReadDir(srcDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -92,7 +91,7 @@ func writeProgram(importPath string, symbols []string) ([]byte, error) {
 
 // run the given program and parse the output as a model.Package.
 func run(program string) (*model.Package, error) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +132,7 @@ func run(program string) (*model.Package, error) {
 // parses the output as a model.Package.
 func runInDir(program []byte, dir string) (*model.Package, error) {
 	// We use TempDir instead of TempFile so we can control the filename.
-	tmpDir, err := ioutil.TempDir(dir, "gomock_reflect_")
+	tmpDir, err := os.MkdirTemp(dir, "gomock_reflect_")
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +148,7 @@ func runInDir(program []byte, dir string) (*model.Package, error) {
 		progBinary += ".exe"
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, progSource), program, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, progSource), program, 0600); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR replaces the deprecated package `io/ioutil` with `io` and `os`.